### PR TITLE
Update purpose type to string and move it into its own file

### DIFF
--- a/src/lib/paths.js
+++ b/src/lib/paths.js
@@ -1,15 +1,10 @@
 import { MAINNET, TESTNET } from "unchained-bitcoin"
 
+import { AccountTypeName } from "./purpose"
+
 const SEPARATOR = "/"
 const APOSTROPHE = "'"
 const COIN_PREFIX = "m"
-
-// Human-readable account names as used by wallets
-const AccountTypeName = {
-  44: "Legacy", // 1addresses
-  49: "SegWit", // 3addresses, SegWit = default
-  84: "Native SegWit", // bc1addresses
-}
 
 function partialKeyDerivationPath(accountNumber, keyIndex) {
   return [accountNumber, keyIndex].join(SEPARATOR)

--- a/src/lib/purpose.js
+++ b/src/lib/purpose.js
@@ -1,0 +1,15 @@
+// Purpose defines the address type
+const Purpose = {
+  P2PKH: "44", // 1...
+  P2SH: "49", // 3...
+  P2WPKH: "84", // bc1...
+}
+
+// Human-readable account names as used by wallets
+export const AccountTypeName = {
+  [Purpose.P2PKH]: "Legacy", // 1addresses
+  [Purpose.P2SH]: "SegWit", // 3addresses, SegWit = default
+  [Purpose.P2WPKH]: "Native SegWit", // bc1addresses
+}
+
+export default Purpose

--- a/src/lib/xpub.js
+++ b/src/lib/xpub.js
@@ -1,13 +1,7 @@
 import * as bitcoin from "bitcoinjs-lib"
 import { deriveChildPublicKey, networkData, TESTNET } from "unchained-bitcoin"
 import { fullDerivationPath, partialKeyDerivationPath } from "../lib/paths.js"
-
-// Purpose defines the address type
-const Purpose = {
-  P2PKH: 44, // 1...
-  P2SH: 49, // 3...
-  P2WPKH: 84, // bc1...
-}
+import Purpose from "./purpose"
 
 const DEFAULT_NETWORK = TESTNET
 const DEFAULT_PURPOSE = Purpose.P2SH
@@ -55,7 +49,7 @@ function addressFromXPub(xpub, accountNumber, keyIndex, purpose, network) {
 
 function deriveAddress(purpose, pubkey, network) {
   let net = networkData(network)
-  switch (Number(purpose)) {
+  switch (purpose) {
     case Purpose.P2PKH: {
       const { address: oneAddress } = bitcoin.payments.p2pkh({
         pubkey: pubkey,


### PR DESCRIPTION
you’re were parsing purpose back to a number here
https://github.com/give-bitcoin/xpub-tool/blob/64a3365eff84df3bae6bacdeba031c86119a925b/src/lib/xpub.js#L58

the reason for that is that the [Purpose Map](https://github.com/give-bitcoin/xpub-tool/blob/64a3365eff84df3bae6bacdeba031c86119a925b/src/lib/xpub.js#L6) is a `String: Int` map and you’re trying to use the same values as keys [here](https://github.com/give-bitcoin/xpub-tool/blob/64a3365eff84df3bae6bacdeba031c86119a925b/src/lib/paths.js#L8).
Unfortunately according to the specs (and [stackoverflow](https://stackoverflow.com/a/3633390)) object keys are always a string.

This PR changes the values to Strings, updates the `AccountTypeMap` and moves both into a separate file so we can incude it in both files (paths.js and xpub.js).