### PR TITLE
chore: rename @swan to @swan-bitcoin

### DIFF
--- a/packages/xpub-components-bootstrap/package.json
+++ b/packages/xpub-components-bootstrap/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@swan/xpub-components-bootstrap",
+  "name": "@swan-bitcoin/xpub-components-bootstrap",
   "private": true,
   "version": "0.0.1",
   "description": "React components for Swan's address derivation tool.",
@@ -23,7 +23,7 @@
     "components"
   ],
   "dependencies": {
-    "@swan/xpub-lib": "^0.0.1",
+    "@swan-bitcoin/xpub-lib": "^0.0.1",
     "prop-types": "^15.7.2",
     "react": "^16.13.1",
     "react-bootstrap": "^1.3.0"

--- a/packages/xpub-components-bootstrap/src/components/addressDerivationInput.js
+++ b/packages/xpub-components-bootstrap/src/components/addressDerivationInput.js
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react"
 import PropTypes from "prop-types"
 import { Form } from "react-bootstrap"
-import { accountDerivationPath, Purpose } from "@swan/xpub-lib"
+import { accountDerivationPath, Purpose } from "@swan-bitcoin/xpub-lib"
 
 const AddressDerivationInput = ({
   maxAccounts = 22,

--- a/packages/xpub-components-bootstrap/src/components/derivedAddressesTable.js
+++ b/packages/xpub-components-bootstrap/src/components/derivedAddressesTable.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { Table } from "react-bootstrap"
-import { maskKey } from "@swan/xpub-lib"
+import { maskKey } from "@swan-bitcoin/xpub-lib"
 
 const DerivedAddressesTable = ({ addressList, showCount, extPubKey }) => {
   return (

--- a/packages/xpub-components-bootstrap/src/components/hardwareWallets.js
+++ b/packages/xpub-components-bootstrap/src/components/hardwareWallets.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { Tabs, Tab } from "react-bootstrap"
 
-import { LEDGER, TREZOR, accountDerivationPath } from "@swan/xpub-lib"
+import { LEDGER, TREZOR, accountDerivationPath } from "@swan-bitcoin/xpub-lib"
 import { ExtPubKeyImporter } from "./xpubImporter"
 
 const HardwareWallets = ({ purpose, accountNumber, network }) => {

--- a/packages/xpub-components-bootstrap/src/components/networkSwitcher.js
+++ b/packages/xpub-components-bootstrap/src/components/networkSwitcher.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { Button, ButtonGroup } from "react-bootstrap"
-import { NETWORKS } from "@swan/xpub-lib"
+import { NETWORKS } from "@swan-bitcoin/xpub-lib"
 
 const SUPPORTED_NETWORKS = [NETWORKS.MAINNET, NETWORKS.TESTNET]
 

--- a/packages/xpub-components-bootstrap/src/components/xpubExamples.js
+++ b/packages/xpub-components-bootstrap/src/components/xpubExamples.js
@@ -1,6 +1,6 @@
 import React from "react"
 
-import { NETWORKS, networkLabel } from "@swan/xpub-lib"
+import { NETWORKS, networkLabel } from "@swan-bitcoin/xpub-lib"
 
 // Mainnet: xpub...
 // Testnet: tpub...

--- a/packages/xpub-components-bootstrap/src/components/xpubImporter.js
+++ b/packages/xpub-components-bootstrap/src/components/xpubImporter.js
@@ -10,7 +10,7 @@ import {
   UNSUPPORTED,
   humanReadableDerivationPath,
   maskKey,
-} from "@swan/xpub-lib"
+} from "@swan-bitcoin/xpub-lib"
 
 class ExtPubKeyImporter extends React.Component {
   constructor(props) {

--- a/packages/xpub-components-bootstrap/src/components/xpubInput.js
+++ b/packages/xpub-components-bootstrap/src/components/xpubInput.js
@@ -1,6 +1,6 @@
 import React, { useMemo } from "react"
 import { Alert, Form } from "react-bootstrap"
-import { isValidExtPubKey } from "@swan/xpub-lib"
+import { isValidExtPubKey } from "@swan-bitcoin/xpub-lib"
 
 const ExtPubKeyInput = ({ extPubKey, network, onChange }) => {
   const isValid = useMemo(() => isValidExtPubKey(extPubKey, network), [

--- a/packages/xpub-components-bootstrap/src/components/xpubMetadata.js
+++ b/packages/xpub-components-bootstrap/src/components/xpubMetadata.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { Table } from "react-bootstrap"
-import { getExtPubKeyMetadata } from "@swan/xpub-lib"
+import { getExtPubKeyMetadata } from "@swan-bitcoin/xpub-lib"
 
 const ExtPubKeyMetadata = ({ extPubKey }) => {
   const meta = getExtPubKeyMetadata(extPubKey)

--- a/packages/xpub-lib/package.json
+++ b/packages/xpub-lib/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@swan/xpub-lib",
+  "name": "@swan-bitcoin/xpub-lib",
   "version": "0.0.1",
   "description": "A JavaScript library for bitcoin address derivation from extended public keys, built upon bitcoinjs-lib and Unchained's bitcoin utilities. Supports P2PKH, P2SH, and P2WPKH (bech32) addresses as defined in BIP44, BIP49, and BIP84.",
   "author": "Gigi <gigi@swanbitcoin.com>",

--- a/packages/xpub-tool/package.json
+++ b/packages/xpub-tool/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@swan/xpub-tool",
+  "name": "@swan-bitcoin/xpub-tool",
   "private": true,
   "version": "0.0.1",
   "description": "A JavaScript tool that derives bitcoin addresses from extended public keys, with support for various hardware wallets.",
@@ -30,8 +30,8 @@
     "wallets"
   ],
   "dependencies": {
-    "@swan/xpub-lib": "0.0.1",
-    "@swan/xpub-components-bootstrap": "0.0.1",
+    "@swan-bitcoin/xpub-lib": "0.0.1",
+    "@swan-bitcoin/xpub-components-bootstrap": "0.0.1",
     "bootstrap": "^4.3.1",
     "gatsby": "^2.3.34",
     "gatsby-image": "^2.0.41",

--- a/packages/xpub-tool/src/pages/hww.js
+++ b/packages/xpub-tool/src/pages/hww.js
@@ -1,12 +1,12 @@
 import React, { useState } from "react"
 import { Form, Row, Col, Container } from "react-bootstrap"
 
-import { Purpose, NETWORKS } from "@swan/xpub-lib"
+import { Purpose, NETWORKS } from "@swan-bitcoin/xpub-lib"
 import {
   NetworkSwitcher,
   AddressDerivationInput,
   HardwareWallets,
-} from "@swan/xpub-components-bootstrap"
+} from "@swan-bitcoin/xpub-components-bootstrap"
 
 import Layout from "../components/layout"
 

--- a/packages/xpub-tool/src/pages/index.js
+++ b/packages/xpub-tool/src/pages/index.js
@@ -6,7 +6,7 @@ import {
   Purpose,
   addressesFromExtPubKey,
   isValidExtPubKey,
-} from "@swan/xpub-lib"
+} from "@swan-bitcoin/xpub-lib"
 
 import {
   DerivedAddressesTable,
@@ -15,7 +15,7 @@ import {
   NetworkSwitcher,
   ExtPubKeyExamples,
   ExtPubKeyMetadata,
-} from "@swan/xpub-components-bootstrap"
+} from "@swan-bitcoin/xpub-components-bootstrap"
 
 import Layout from "../components/layout"
 


### PR DESCRIPTION
Swan was already taken on npm, I chose `swan-bitcoin` for consistency with our GitHub org name.