### PR TITLE
fix(cli): fix `--verbose` output for large `--addressCount`

### DIFF
--- a/packages/xpub-cli/src/xpub.js
+++ b/packages/xpub-cli/src/xpub.js
@@ -28,6 +28,14 @@ function parsePurpose(purpose) {
   }
 }
 
+function printAddress(address, verbose = false) {
+  if (verbose) {
+    console.log(address)
+  } else {
+    console.log(address.address)
+  }
+}
+
 const { program } = require("commander")
 
 program.version(`${version}`)
@@ -85,7 +93,9 @@ program
         purpose,
         network,
       })
-      cmdObj.verbose ? console.log(addresses) : console.log(addresses.map(({ address }) => (address)))
+      addresses.forEach(address => {
+        printAddress(address, cmdObj.verbose)
+      })
     } else {
       // Single address
       const address = addressFromExtPubKey({
@@ -95,7 +105,7 @@ program
         purpose,
         network,
       })
-      cmdObj.verbose ? console.log(address) : console.log(address.address)
+      printAddress(address, cmdObj.verbose)
     }
   })
 

--- a/packages/xpub-cli/src/xpub.js
+++ b/packages/xpub-cli/src/xpub.js
@@ -85,7 +85,7 @@ program
         purpose,
         network,
       })
-      console.log(addresses)
+      cmdObj.verbose ? console.log(addresses) : console.log(addresses.map(({ address }) => (address)))
     } else {
       // Single address
       const address = addressFromExtPubKey({
@@ -95,8 +95,7 @@ program
         purpose,
         network,
       })
-      if (cmdObj.verbose) console.log(address)
-      console.log(address.address)
+      cmdObj.verbose ? console.log(address) : console.log(address.address)
     }
   })
 


### PR DESCRIPTION
Output was cut off for large `-n`, i.e. the output would end with:

```
    address: 'bc1qj7yzj42dyrvcj2lk49hnnh43gvcpgm6kyzlhmk'
  },
  ... 1237 more items
]
```