### PR TITLE
ci: wrap dependency installs with egress-lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,19 @@ jobs:
           node-version-file: '.nvmrc'
           registry-url: 'https://npm.pkg.github.com'
           scope: '@swan-bitcoin'
-      - name: Install dependencies 
+      - name: Egress lock
+        if: vars.EGRESS_LOCK_ENABLED == 'true'
+        uses: swan-bitcoin/actions/swan/egress-lock@master
+        with:
+          report-only: ${{ vars.EGRESS_LOCK_REPORT_ONLY }}
+      - name: Install dependencies
         run: yarn install --frozen-lockfile
+      - name: Egress unlock
+        if: always() && vars.EGRESS_LOCK_ENABLED == 'true'
+        uses: swan-bitcoin/actions/swan/egress-unlock@master
+      - name: Egress report
+        if: always() && vars.EGRESS_LOCK_ENABLED == 'true'
+        uses: swan-bitcoin/actions/swan/egress-report@master
       - name: Build
         run: yarn workspaces run compile
       - name: Run tests 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -16,7 +16,18 @@ jobs:
           node-version-file: '.nvmrc'
           registry-url: 'https://npm.pkg.github.com'
           scope: '@swan-bitcoin'
+      - name: Egress lock
+        if: vars.EGRESS_LOCK_ENABLED == 'true'
+        uses: swan-bitcoin/actions/swan/egress-lock@master
+        with:
+          report-only: ${{ vars.EGRESS_LOCK_REPORT_ONLY }}
       - run: yarn install --frozen-lockfile
+      - name: Egress unlock
+        if: always() && vars.EGRESS_LOCK_ENABLED == 'true'
+        uses: swan-bitcoin/actions/swan/egress-unlock@master
+      - name: Egress report
+        if: always() && vars.EGRESS_LOCK_ENABLED == 'true'
+        uses: swan-bitcoin/actions/swan/egress-report@master
       - run: yarn workspaces run compile
       # publish xpub-lib
       - run: yarn publish packages/xpub-lib --access public


### PR DESCRIPTION
## Summary
- Wraps `yarn install` steps in CI workflows with the egress-lock / egress-unlock / egress-report pattern already used in `api`.
- Gated by `EGRESS_LOCK_ENABLED` repo/org variable so it's a no-op until enabled.

## Test plan
- [ ] CI passes (no behavior change while `EGRESS_LOCK_ENABLED` is unset)
- [ ] After flipping `EGRESS_LOCK_ENABLED=true`, install steps are gated by egress lock

Linear: [PSEC-4782](https://linear.app/swanbitcoin/issue/PSEC-4782)