### PR TITLE
chore(security): SHA-pin CI actions + vendor the Linear check (public repo) [PSEC-5221]

### DIFF
--- a/.github/actions/check-linear-link/action.yml
+++ b/.github/actions/check-linear-link/action.yml
@@ -1,0 +1,93 @@
+# Local copy of swan-bitcoin/actions/swan/check-linear-link.
+#
+# This is a PUBLIC repo, so it cannot resolve the private swan-bitcoin/actions
+# mirror at workflow-prep time (no token before the first authenticated checkout;
+# a PAT for an explicit mirror checkout does not propagate to transitive action
+# resolution — see PSEC-4907). Vendoring the composite locally avoids the mirror
+# entirely. The only external action it calls (actions/github-script) is pinned to
+# a full commit SHA. Keep in sync with the upstream swan action.
+name: 'Check Linear Ticket Link'
+description: 'Checks if PR description contains a valid Linear ticket URL'
+author: 'Swan Bitcoin'
+branding:
+  icon: 'check-circle'
+  color: 'green'
+
+inputs:
+  skip-prefixes:
+    description: 'Comma-separated list of PR title prefixes to skip (conventional commit types). Set to empty string to disable.'
+    required: false
+    default: 'build:,chore:,ci:,docs:,perf:,refactor:,style:,test:'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Check for Linear ticket link
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+      with:
+        script: |
+          // Only run validation in pull_request context
+          if (!context.payload.pull_request) {
+            console.log('✅ Not a pull_request context, skipping Linear check');
+            return;
+          }
+
+          const prNumber = context.payload.pull_request.number;
+
+          // Fetch current PR state from API to get latest title/body
+          // (event payload may be stale if workflow is manually re-run)
+          const { data: pr } = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: prNumber,
+          });
+
+          const prTitle = pr.title || '';
+          const prBody = pr.body || '';
+          const skipPrefixes = '${{ inputs.skip-prefixes }}'.split(',').map(p => p.trim()).filter(Boolean);
+
+          // Check if PR title starts with a skip prefix (conventional commits)
+          // Supports optional scope: "type:" or "type(scope):"
+          // See: https://www.conventionalcommits.org/en/v1.0.0/
+          for (const prefix of skipPrefixes) {
+            // Extract the type (everything before the colon)
+            const type = prefix.replace(/:$/, '');
+            // Match "type:" or "type(scope):" at the start
+            const pattern = new RegExp(`^${type}(\\([^)]+\\))?:`);
+            if (pattern.test(prTitle)) {
+              const match = prTitle.match(pattern)[0];
+              console.log(`✅ Skipping Linear check: PR title starts with "${match}"`);
+              return;
+            }
+          }
+
+          const linearPattern = /https:\/\/linear\.app\/[^\/]+\/issue\/[A-Z]+-\d+/g;
+
+          // Check for Linear bot comment
+          const comments = await github.rest.issues.listComments({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: prNumber,
+          });
+
+          const linearBotComment = comments.data.find(comment =>
+            comment.user.login === 'linear[bot]' || comment.user.login === 'linear-code[bot]'
+          );
+
+          if (linearBotComment) {
+            const matches = linearBotComment.body.match(linearPattern);
+            if (matches && matches.length > 0) {
+              console.log(`✅ Found Linear ticket URL(s) in Linear bot comment: ${matches.join(', ')}`);
+              return;
+            }
+          }
+
+          // Fallback: Check PR body for Linear ticket link
+          const prBodyMatches = prBody.match(linearPattern);
+
+          if (prBodyMatches && prBodyMatches.length > 0) {
+            console.log(`✅ Found Linear ticket URL(s) in PR description: ${prBodyMatches.join(', ')}`);
+            return;
+          }
+
+          core.setFailed('No Linear ticket link found in Linear bot comment or PR description. Please link this PR to a Linear ticket.');

--- a/.github/actions/check-linear-link/action.yml
+++ b/.github/actions/check-linear-link/action.yml
@@ -1,11 +1,3 @@
-# Local copy of swan-bitcoin/actions/swan/check-linear-link.
-#
-# This is a PUBLIC repo, so it cannot resolve the private swan-bitcoin/actions
-# mirror at workflow-prep time (no token before the first authenticated checkout;
-# a PAT for an explicit mirror checkout does not propagate to transitive action
-# resolution — see PSEC-4907). Vendoring the composite locally avoids the mirror
-# entirely. The only external action it calls (actions/github-script) is pinned to
-# a full commit SHA. Keep in sync with the upstream swan action.
 name: 'Check Linear Ticket Link'
 description: 'Checks if PR description contains a valid Linear ticket URL'
 author: 'Swan Bitcoin'

--- a/.github/workflows/check-linear-link.yml
+++ b/.github/workflows/check-linear-link.yml
@@ -1,0 +1,35 @@
+name: Linear
+
+# Public repo: the private swan-bitcoin/actions mirror can't be resolved at
+# workflow-prep time, so the Linear check runs from a local copy of the swan action
+# vendored at .github/actions/check-linear-link (its only external action,
+# actions/github-script, is SHA-pinned there). External actions are SHA-pinned.
+
+on:
+  pull_request:
+    branches: [ "master" ]
+    types: [opened, synchronize, reopened, edited]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  # Job name must be `check-linear-link` — the `require-linear-status-check` ruleset
+  # requires that exact status-check context on `master`.
+  check-linear-link:
+    runs-on: ubuntu-latest
+    # Skip on draft, revert branches (for rollback speed), or dependabot PRs (no Linear ticket required)
+    if: |
+      github.event.pull_request.draft == false &&
+      !startsWith(github.head_ref, 'revert-') &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
+    steps:
+      - name: Checkout (for the local action)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Check Linear Link
+        uses: ./.github/actions/check-linear-link

--- a/.github/workflows/check-linear-link.yml
+++ b/.github/workflows/check-linear-link.yml
@@ -14,8 +14,6 @@ permissions:
   contents: read
 
 jobs:
-  # Job name must be `check-linear-link` — the `require-linear-status-check` ruleset
-  # requires that exact status-check context on `master`.
   check-linear-link:
     runs-on: ubuntu-latest
     # Skip on draft, revert branches (for rollback speed), or dependabot PRs (no Linear ticket required)

--- a/.github/workflows/check-linear-link.yml
+++ b/.github/workflows/check-linear-link.yml
@@ -1,10 +1,5 @@
 name: Linear
 
-# Public repo: the private swan-bitcoin/actions mirror can't be resolved at
-# workflow-prep time, so the Linear check runs from a local copy of the swan action
-# vendored at .github/actions/check-linear-link (its only external action,
-# actions/github-script, is SHA-pinned there). External actions are SHA-pinned.
-
 on:
   pull_request:
     branches: [ "master" ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
     env:
       NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Enable Corepack
         run: corepack enable
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://npm.pkg.github.com'

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,10 +12,10 @@ jobs:
     env:
       NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Enable Corepack
         run: corepack enable
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version-file: '.nvmrc'
           registry-url: 'https://npm.pkg.github.com'


### PR DESCRIPTION
## What

Harden this public repo's CI supply-chain posture:

- **Pin external actions to commit SHAs.** `actions/checkout` and `actions/setup-node` in `ci.yml` and `publish.yaml` are pinned to full commit SHAs instead of moving tags.
- **Add the required `check-linear-link` workflow.** A small local composite action at `.github/actions/check-linear-link` validates that the PR links a Linear ticket; its only external action (`actions/github-script`) is SHA-pinned.

## Why

Pinning every action to a commit SHA removes the mutable-tag supply-chain risk — a tag can be re-pointed, a SHA cannot. The repo's `require-linear-status-check` ruleset requires a `check-linear-link` status context, which this adds.

Linear: PSEC-5221

🤖 Generated with [Claude Code](https://claude.com/claude-code)
