### PR TITLE
ci: add supply-chain-lint gate

### DIFF
--- a/.github/actions/supply-chain-lint/action.yml
+++ b/.github/actions/supply-chain-lint/action.yml
@@ -1,0 +1,32 @@
+name: "Supply Chain Lint"
+description: "Scans vendored actions for runtime supply chain risks (runtime installs, unpinned versions, disabled lockfiles)"
+author: "Swan Bitcoin"
+branding:
+  icon: "shield"
+  color: "orange"
+
+inputs:
+  allowlist-path:
+    description: "Path to a repo-specific allowlist file (relative to repository root). Entries are merged with the built-in allowlist."
+    required: false
+    default: ""
+
+outputs:
+  violations_found:
+    description: "Whether any supply chain violations were found"
+    value: ${{ steps.lint.outputs.violations_found }}
+  violation_count:
+    description: "Number of violations found"
+    value: ${{ steps.lint.outputs.violation_count }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Run supply chain lint
+      id: lint
+      shell: bash
+      run: bash ${{ github.action_path }}/supply-chain-lint.sh
+      env:
+        SCAN_ROOT: ${{ github.workspace }}
+        BUILTIN_ALLOWLIST_PATH: ${{ github.action_path }}/supply-chain-allowlist.yml
+        REPO_ALLOWLIST_PATH: ${{ inputs.allowlist-path && format('{0}/{1}', github.workspace, inputs.allowlist-path) || '' }}

--- a/.github/actions/supply-chain-lint/supply-chain-allowlist.yml
+++ b/.github/actions/supply-chain-lint/supply-chain-allowlist.yml
@@ -1,0 +1,89 @@
+# Supply Chain Allowlist
+#
+# Vendored actions cannot be modified (would fail verify-action), so known
+# supply chain risks in third-party actions are allowlisted here with metadata.
+#
+# Format:
+#   - file: "path/to/file"
+#     pattern: "matched text"
+#     reason: "why this is acceptable"
+#     date: "YYYY-MM-DD"
+#
+# `pattern` is matched as a substring against the actual offending line.
+# Keep it as specific as possible (e.g. include the package names installed
+# by an apt-get line) so the entry doesn't silently cover unrelated future
+# installs added in the same file.
+
+# anthropics/claude-code-action uses bun install --production with bun.lock
+# present, but without --frozen-lockfile. Cannot modify vendored action.
+- file: "anthropics/claude-code-action/base-action/action.yml"
+  pattern: "bun install"
+  reason: "Vendored action; has bun.lock but no --frozen-lockfile. Cannot modify without failing verify-action."
+  date: "2026-04-07"
+
+- file: "anthropics/claude-code-action/action.yml"
+  pattern: "bun install"
+  reason: "Vendored action; has bun.lock but no --frozen-lockfile. Cannot modify without failing verify-action."
+  date: "2026-04-07"
+
+# github/codeql-action ships dev scripts (pr-checks/sync.sh, scripts/check-node-modules.sh)
+# that contain npm install and npx calls. These are not runtime action code — they are
+# development tooling that ships with the vendored action and cannot be modified.
+# TODO(TIS-988): Remove these entries — stripping scripts/ and pr-checks/ dirs from
+# vendored actions will eliminate these files entirely.
+- file: "github/codeql-action/pr-checks/sync.sh"
+  pattern: "npm install"
+  reason: "Vendored dev script, not executed at runtime. Cannot modify without failing verify-action."
+  date: "2026-04-07"
+
+# TODO(TIS-988): Remove — file will be stripped from vendored action.
+- file: "github/codeql-action/pr-checks/sync.sh"
+  pattern: "npx"
+  reason: "Vendored dev script, not executed at runtime. Cannot modify without failing verify-action."
+  date: "2026-04-07"
+
+# TODO(TIS-988): Remove — file will be stripped from vendored action.
+- file: "github/codeql-action/scripts/check-node-modules.sh"
+  pattern: "npm install"
+  reason: "Vendored dev script, not executed at runtime. Cannot modify without failing verify-action."
+  date: "2026-04-07"
+
+# anthropics/claude-code-action installs bubblewrap+socat for subprocess
+# isolation, but only when `allowed_non_write_users` is set. No consumer in
+# this repo passes that input, so the apt-get step is gated off and never
+# runs. Step also carries `continue-on-error: true` upstream. If a future
+# consumer enables `allowed_non_write_users`, revisit this entry.
+- file: "anthropics/claude-code-action/action.yml"
+  pattern: "apt-get install -y --no-install-recommends bubblewrap socat"
+  reason: "Gated on allowed_non_write_users input; no consumer in this repo sets it, so the step never executes. Vendored action cannot be modified. Pattern is line-specific so any other apt-get install added upstream still trips the lint."
+  date: "2026-06-03"
+
+# swan/claude-code-security-review installs system packages (gh, jq) via apt-get.
+# These come from Ubuntu's package repos which are distribution-pinned.
+- file: "swan/claude-code-security-review/action.yml"
+  pattern: "apt-get install"
+  reason: "System packages (gh, jq) from Ubuntu repos; distribution-pinned and required for CI."
+  date: "2026-04-07"
+
+# swan/egress-lock installs tinyproxy via apt-get for network egress filtering.
+# System package from Ubuntu repos, distribution-pinned.
+- file: "swan/egress-lock/action.yml"
+  pattern: "apt-get install"
+  reason: "System package (tinyproxy) from Ubuntu repos; distribution-pinned, required for egress filtering."
+  date: "2026-04-09"
+
+# swan/cambium-ci-review installs Ruby via apt-get for the Cambium DSL compiler
+# (pipeline sub-gens are compiled on demand via ruby compile.rb). System package
+# from Ubuntu repos, distribution-pinned.
+- file: "swan/cambium-ci-review/action.yml"
+  pattern: "apt-get install"
+  reason: "System package (ruby) from Ubuntu repos; distribution-pinned, required for Cambium DSL compiler."
+  date: "2026-05-22"
+
+# swan/cambium-ci-review installs Node dependencies from package-lock.json at
+# runtime. The lockfile is committed and --ignore-scripts prevents post-install
+# code execution.
+- file: "swan/cambium-ci-review/action.yml"
+  pattern: "npm ci"
+  reason: "Strict lockfile install from committed package-lock.json with --ignore-scripts; required for Cambium pipeline runner."
+  date: "2026-05-22"

--- a/.github/actions/supply-chain-lint/supply-chain-lint.sh
+++ b/.github/actions/supply-chain-lint/supply-chain-lint.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+
+# Supply Chain Lint — scans vendored actions for runtime supply chain risks
+#
+# Detects: runtime package installs, unpinned versions, disabled lockfiles,
+#          curl|bash, and other supply chain risks in action.yml and .sh files.
+#
+# Violations are checked against a supply-chain-allowlist.yml.
+# Non-allowlisted violations cause exit 1.
+#
+# Environment variables (set by composite action, optional for direct use):
+#   SCAN_ROOT      — directory to scan (defaults to parent of script dir)
+#   ALLOWLIST_PATH — path to allowlist YAML (defaults to $SCRIPT_DIR/supply-chain-allowlist.yml)
+
+set -eo pipefail
+
+# ── Patterns (edit here to add/remove checks) ───────────────────────────────
+#
+# Each entry has 4 fields separated by "::":
+#
+#   category :: grep_pattern :: detail :: exclude_string
+#
+#   category       — grouping label for the violation
+#   grep_pattern   — extended regex passed to grep -E
+#   detail         — human-readable description (used for allowlist matching)
+#   exclude_string — optional fixed string(s); lines containing this are skipped
+#                    use comma to separate multiple excludes (applied independently)
+#
+# Lines matching echo/printf/description:/# comments are always skipped.
+
+PATTERNS=(
+  # ── Runtime install commands ──────────────────────────────────────────────
+  "runtime-install :: npm install           :: npm install                         :: npm ci"
+  "runtime-install :: npx                   :: npx                                :: "
+  "runtime-install :: pip3? install         :: pip install without constraints     :: -c "
+  "runtime-install :: yarn install          :: yarn install without lockfile pinning :: frozen-lockfile,--immutable"
+  "runtime-install :: bun install           :: bun install without --frozen-lockfile  :: frozen-lockfile"
+  "runtime-install :: curl .+\| *bash      :: curl|bash                           :: "
+  "runtime-install :: curl .+\| *sh[^a-z]  :: curl|sh                             :: "
+  "runtime-install :: apt-get install       :: apt-get install                     :: "
+  "runtime-install :: apk add              :: apk add                             :: "
+
+  # ── Unpinned versions ─────────────────────────────────────────────────────
+  "unpinned-version :: @latest              :: @latest                             :: "
+  "unpinned-version :: --no-package-lock    :: lockfile explicitly disabled        :: "
+  "unpinned-version :: --no-lockfile        :: lockfile explicitly disabled        :: "
+)
+
+# ── Setup ────────────────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${SCAN_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+# Allowlist files: built-in (ships with the action) + optional repo-specific
+BUILTIN_ALLOWLIST="${BUILTIN_ALLOWLIST_PATH:-$SCRIPT_DIR/supply-chain-allowlist.yml}"
+REPO_ALLOWLIST="${REPO_ALLOWLIST_PATH:-}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+error() { echo -e "${RED}$1${NC}"; }
+info()  { echo -e "${GREEN}$1${NC}"; }
+bold()  { echo -e "${BOLD}$1${NC}"; }
+
+cd "$REPO_ROOT"
+
+# Compute self-exclusion path: skip the lint script's own directory to avoid
+# false positives from pattern definitions in this file
+SELF_EXCLUDE=""
+if [[ "$SCRIPT_DIR" == "$REPO_ROOT"/* ]]; then
+  SELF_EXCLUDE="${SCRIPT_DIR#$REPO_ROOT/}"
+fi
+
+VIOLATIONS_FILE=$(mktemp)
+trap "rm -f $VIOLATIONS_FILE" EXIT
+
+# ── Pre-parse allowlist ──────────────────────────────────────────────────────
+
+# Build a flat list of "file|pattern" pairs from allowlist YAML files
+ALLOWLIST_ENTRIES=""
+
+parse_allowlist() {
+  local file="$1"
+  [[ ! -f "$file" ]] && return
+  local current_file=""
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ "$line" =~ ^[[:space:]]*$ ]] && continue
+    if [[ "$line" =~ ^[[:space:]]*-[[:space:]]*file: ]]; then
+      current_file=$(echo "$line" | sed -E 's/^[[:space:]]*-[[:space:]]*file:[[:space:]]*//' | tr -d '"' | tr -d "'")
+    elif [[ "$line" =~ ^[[:space:]]+pattern: ]]; then
+      local current_pattern
+      current_pattern=$(echo "$line" | sed -E 's/^[[:space:]]*pattern:[[:space:]]*//' | tr -d '"' | tr -d "'")
+      ALLOWLIST_ENTRIES="${ALLOWLIST_ENTRIES}${current_file}|${current_pattern}"$'\n'
+    fi
+  done < "$file"
+}
+
+parse_allowlist "$BUILTIN_ALLOWLIST"
+parse_allowlist "$REPO_ALLOWLIST"
+
+# Allowlist match: the allowlist `pattern` must appear as a substring of the
+# actual matched line. This lets entries narrow exactly which lines they cover
+# (e.g. "apt-get install -y --no-install-recommends bubblewrap socat") so that
+# any future apt-get install with different packages is still flagged.
+is_line_allowlisted() {
+  local file="$1"
+  local line_content="$2"
+
+  while IFS='|' read -r al_file al_pattern; do
+    [[ -z "$al_file" ]] && continue
+    if [[ "$file" == "$al_file" ]]; then
+      if [[ "$line_content" == *"$al_pattern"* ]]; then
+        return 0
+      fi
+    fi
+  done <<< "$ALLOWLIST_ENTRIES"
+  return 1
+}
+
+# ── Collect files to scan ────────────────────────────────────────────────────
+
+bold "Supply Chain Lint"
+echo "======================================================================"
+echo ""
+
+# Collect action.yml/yaml and sibling .sh files, excluding:
+#   - .git/
+#   - .github/ dirs inside vendored actions
+#   - __tests__/, __test__/, test/, tests/ dirs (vendored test fixtures)
+#   - scripts/ dirs in vendored actions (dev scripts, not runtime)
+FILES_TO_SCAN=$(mktemp)
+
+# Directories to skip inside vendored actions
+SKIP_DIRS="\.git|\.github|__tests__|__test__|/tests/|/test/"
+
+# Helper: filter out the lint script's own directory from scan results
+self_exclude_filter() {
+  if [[ -n "$SELF_EXCLUDE" ]]; then
+    grep -v "^${SELF_EXCLUDE}/" || true
+  else
+    cat
+  fi
+}
+
+# Action files (top-level action.yml/yaml that define the action)
+find . -name ".git" -prune -o \( -name "action.yml" -o -name "action.yaml" \) -print 2>/dev/null | \
+  (grep -vE "/(${SKIP_DIRS})/" || true) | sed 's|^\./||' | self_exclude_filter | sort >> "$FILES_TO_SCAN"
+
+# Shell scripts in the same directories as action files (runtime scripts)
+find . -name ".git" -prune -o \( -name "action.yml" -o -name "action.yaml" \) -print 2>/dev/null | \
+  (grep -vE "/(${SKIP_DIRS})/" || true) | while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    find "$(dirname "$f")" -maxdepth 3 -name "*.sh" 2>/dev/null
+  done | (grep -vE "/(${SKIP_DIRS})/" || true) | sed 's|^\./||' | self_exclude_filter | sort -u >> "$FILES_TO_SCAN"
+
+FILE_COUNT=$(wc -l < "$FILES_TO_SCAN" | tr -d ' ')
+info "Scanning ${FILE_COUNT} files..."
+echo ""
+
+# ── Scan ─────────────────────────────────────────────────────────────────────
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  [[ ! -f "$file" ]] && continue
+
+  for pattern_entry in "${PATTERNS[@]}"; do
+    # Split on " :: " delimiter and trim whitespace
+    category=$(echo "$pattern_entry"    | awk -F' :: ' '{print $1}' | sed 's/^ *//;s/ *$//')
+    grep_pat=$(echo "$pattern_entry"    | awk -F' :: ' '{print $2}' | sed 's/^ *//;s/ *$//')
+    detail=$(echo "$pattern_entry"      | awk -F' :: ' '{print $3}' | sed 's/^ *//;s/ *$//')
+    exclude_pat=$(echo "$pattern_entry" | awk -F' :: ' '{print $4}' | sed 's/^ *//;s/ *$//')
+
+    # Use grep -E to find matching lines, filtering out comments/echo/description
+    matches=$(grep -nE -- "$grep_pat" "$file" 2>/dev/null | \
+      grep -vE '^\s*#|^[0-9]+:\s*#' | \
+      grep -vE '^\s*echo |^[0-9]+:\s*echo |^[0-9]+:\s*printf ' | \
+      grep -vE '^\s*description:|^[0-9]+:\s*description:' || true)
+
+    [[ -z "$matches" ]] && continue
+
+    # Apply exclude patterns if present (comma-separated, each applied independently)
+    if [[ -n "$exclude_pat" ]]; then
+      IFS=',' read -ra excludes <<< "$exclude_pat"
+      for ex in "${excludes[@]}"; do
+        matches=$(echo "$matches" | grep -vF -- "$ex" || true)
+        [[ -z "$matches" ]] && break
+      done
+      [[ -z "$matches" ]] && continue
+    fi
+
+    # Drop allowlisted lines (matched per-line against actual content).
+    unallowlisted=""
+    while IFS= read -r match_line; do
+      [[ -z "$match_line" ]] && continue
+      # Strip the leading "lineno:" prefix from grep -n output
+      content="${match_line#*:}"
+      if ! is_line_allowlisted "$file" "$content"; then
+        unallowlisted="${unallowlisted}${match_line}"$'\n'
+      fi
+    done <<< "$matches"
+
+    # Record one violation per file per pattern (not per line)
+    if [[ -n "$(printf '%s' "$unallowlisted" | tr -d '[:space:]')" ]]; then
+      echo "${file}|${category}|${detail}" >> "$VIOLATIONS_FILE"
+    fi
+  done
+done < "$FILES_TO_SCAN"
+
+rm -f "$FILES_TO_SCAN"
+
+# ── Results ──────────────────────────────────────────────────────────────────
+
+echo ""
+bold "Results"
+echo "======================================================================"
+
+if [[ ! -s "$VIOLATIONS_FILE" ]]; then
+  echo ""
+  info "No supply chain violations found."
+  echo ""
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "violations_found=false" >> "$GITHUB_OUTPUT"
+    echo "violation_count=0" >> "$GITHUB_OUTPUT"
+  fi
+  exit 0
+fi
+
+UNIQUE_VIOLATIONS=$(sort -u "$VIOLATIONS_FILE")
+VIOLATION_COUNT=$(echo "$UNIQUE_VIOLATIONS" | wc -l | tr -d ' ')
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  echo "violations_found=true" >> "$GITHUB_OUTPUT"
+  echo "violation_count=$VIOLATION_COUNT" >> "$GITHUB_OUTPUT"
+fi
+
+echo ""
+error "Found ${VIOLATION_COUNT} supply chain violation(s):"
+echo ""
+
+echo "$UNIQUE_VIOLATIONS" | while IFS='|' read -r v_file v_category v_detail; do
+  echo -e "  ${RED}●${NC} ${BOLD}${v_file}${NC}"
+  echo -e "    Category: ${v_category}"
+  echo -e "    Detail:   ${v_detail}"
+  echo ""
+done
+
+echo "======================================================================"
+error "Supply chain lint failed with ${VIOLATION_COUNT} violation(s)."
+echo ""
+echo "To fix: either resolve the issue directly, or add an entry to"
+echo "  the supply-chain-allowlist.yml (built-in or repo-specific)"
+echo "with a justification."
+echo ""
+exit 1

--- a/.github/workflows/supply-chain-lint.yml
+++ b/.github/workflows/supply-chain-lint.yml
@@ -1,0 +1,43 @@
+name: Supply chain lint
+
+# Scans GitHub Actions (`action.yml`/`action.yaml` and sibling `.sh` scripts)
+# for runtime supply-chain risks: `npm install` without `npm ci`, `curl | bash`,
+# unpinned `@latest`, `--no-lockfile`, etc. The scanner skips `.github/` by
+# design, so the vendored `check-linear-link` action is not scanned today — the
+# gate acts as a tripwire for any vendored action added outside `.github/` later.
+#
+# xpub-tool is a public repo, so it cannot resolve the private
+# swan-bitcoin/actions mirror at workflow-prep time. Instead (same pattern as
+# swan-vault-recovery-assistant) it checks the mirror out explicitly with a PAT
+# and runs the lint as a local action — supply-chain-lint is a self-contained
+# composite (bash only, no transitive `uses:`), so this works.
+#
+# Source: https://github.com/swan-bitcoin/actions/blob/master/swan/supply-chain-lint/README.md
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    types: [opened, synchronize]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  supply-chain-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: checkout private actions
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          repository: swan-bitcoin/actions
+          ref: master
+          token: ${{ secrets.GH_PAT_ACTIONS_ACCESS }}
+          path: .github/private-actions
+
+      - name: supply chain lint
+        uses: ./.github/private-actions/swan/supply-chain-lint

--- a/.github/workflows/supply-chain-lint.yml
+++ b/.github/workflows/supply-chain-lint.yml
@@ -3,14 +3,17 @@ name: Supply chain lint
 # Scans GitHub Actions (`action.yml`/`action.yaml` and sibling `.sh` scripts)
 # for runtime supply-chain risks: `npm install` without `npm ci`, `curl | bash`,
 # unpinned `@latest`, `--no-lockfile`, etc. The scanner skips `.github/` by
-# design, so the vendored `check-linear-link` action is not scanned today — the
-# gate acts as a tripwire for any vendored action added outside `.github/` later.
+# design, so the vendored actions under `.github/actions/` are not scanned
+# today — the gate acts as a tripwire for any vendored action added outside
+# `.github/` later.
 #
-# xpub-tool is a public repo, so it cannot resolve the private
-# swan-bitcoin/actions mirror at workflow-prep time. Instead (same pattern as
-# swan-vault-recovery-assistant) it checks the mirror out explicitly with a PAT
-# and runs the lint as a local action — supply-chain-lint is a self-contained
-# composite (bash only, no transitive `uses:`), so this works.
+# xpub-tool is a public repo, so it must not reference (or have access to) the
+# private swan-bitcoin/actions repo. Like `check-linear-link`, the action is
+# vendored into `.github/actions/supply-chain-lint` — a verbatim copy of
+# swan/supply-chain-lint from swan-bitcoin/actions@63912e4cae62a3786793d1fd5d903e8a480685d5.
+# It is a self-contained bash composite with no transitive `uses:`, so the copy
+# has no external references to pin. Re-sync it from the actions repo when the
+# upstream action changes.
 #
 # Source: https://github.com/swan-bitcoin/actions/blob/master/swan/supply-chain-lint/README.md
 
@@ -31,13 +34,5 @@ jobs:
       - name: checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - name: checkout private actions
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          repository: swan-bitcoin/actions
-          ref: master
-          token: ${{ secrets.GH_PAT_ACTIONS_ACCESS }}
-          path: .github/private-actions
-
       - name: supply chain lint
-        uses: ./.github/private-actions/swan/supply-chain-lint
+        uses: ./.github/actions/supply-chain-lint


### PR DESCRIPTION
## Summary

Adds the fleet-standard `supply-chain-lint` gate, part of closing the `gate:supply-chain-lint` finding category from the weekly repo-security-lint sweep ([PSEC-5231](https://linear.app/swanbitcoin/issue/PSEC-5231/wire-up-the-supply-chain-lint-ci-gate-3-repos)).

## What it does

`supply-chain-lint` scans vendored GitHub Action definitions (`action.yml`/`action.yaml` and sibling `.sh` scripts) for runtime supply-chain risks — runtime installs that bypass lockfiles (`npm install`, `npx`, `curl | bash`), and unpinned versions (`@latest`, `--no-lockfile`).

xpub-tool is a **public** repo, so it must not reference (or hold credentials for) the private `swan-bitcoin/actions` repo. Following the `check-linear-link` precedent (#72), the action is **vendored into the repo** at `.github/actions/supply-chain-lint/` — a verbatim copy of `swan/supply-chain-lint` from `swan-bitcoin/actions@63912e4` (`action.yml`, `supply-chain-lint.sh`, built-in allowlist). It is a self-contained bash composite with no transitive `uses:` refs, so the copy has no external references to pin. The workflow checks out the repo (SHA-pinned `actions/checkout`) and runs the local action.

The scanner deliberately skips `.github/`, and this repo's vendored actions all live there — so the lint scans 0 files today and passes as a no-op (verified locally). It acts as a tripwire for any vendored action added outside `.github/` later.

## Verification

Ran the vendored script locally against the branch worktree: `Scanning 0 files... No supply chain violations found.` The `gate:supply-chain-lint` check in `repo-security-lint` greps workflows for the action ref — this workflow satisfies it; the next weekly fleet sweep will confirm.

## Pre-existing issue (not addressed here)

`.github/workflows/dependency-review.yml` on master still references the private mirror (`swan-bitcoin/actions/...@master`), which cannot resolve from this public repo — it fails at workflow-prep on every PR (all runs since 2026-06-26 failed with zero jobs). It needs the same public-repo treatment (SHA-pinned upstream `actions/dependency-review-action`; the `analyze-dependency-changes` job has transitive mirror refs — PSEC-4907 precedent). Tracked in PSEC-5231's Linear thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)