### PR TITLE
chore(security): add CODEOWNERS protecting .github/ [PSEC-5222]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.github/    @swan-bitcoin/ProdSec @swan-bitcoin/Security


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` protecting `.github/` (build/CI config) with ProdSec + Security as required reviewers. A directory rule covers everything beneath it, so this also protects the CODEOWNERS file itself.
- All other paths remain open — anyone with write access can approve.

## Why
`repo-security-lint` Pillar D flagged this repo with no CODEOWNERS file at all (check `codeowners`), per the fleet sweep [run 29567660654](https://github.com/swan-bitcoin/ai-root/actions/runs/29567660654).

Part of [PSEC-5222](https://linear.app/swanbitcoin/issue/PSEC-5222/add-codeowners-mapping-sensitive-paths-to-owning-teams-8-repos).

## Test plan
- [ ] Re-run `repo-security-lint` against this repo and confirm `codeowners` and `codeowners-protects-ci` both pass